### PR TITLE
Use bzip2 -d instead of bunzip2

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -83,7 +83,7 @@ module.exports = function(shipit) {
   };
 
   var load = function load(file, environment) {
-    var cmd = sprintf('bunzip2 -f %(file)s && %(createCmd)s && %(importCmd)s', {
+    var cmd = sprintf('bzip2 -d -f %(file)s && %(createCmd)s && %(importCmd)s', {
       file: file,
       importCmd: importCmd(file, environment),
       createCmd: createCmd(environment)


### PR DESCRIPTION
This is a PR that remedies the problem reported in #9. I've been informed that `bunzip2` is in fact an alias for `bzip2 -d`. Using the latter resolved the issue; it seemed the server had `bzip2` installed, but not the alias. Not sure if #9 is still relevant, feel free to close if not!
