### PR TITLE
db:finish task and dbFinish event

### DIFF
--- a/tasks/db/finish.js
+++ b/tasks/db/finish.js
@@ -1,0 +1,17 @@
+var utils = require('shipit-utils');
+var db = require('../../lib/db');
+
+/**
+ * Finish task.
+ * - Emit an event "dbFinish".
+ */
+
+module.exports = function (gruntOrShipit) {
+  utils.registerTask(gruntOrShipit, 'db:finish', task);
+
+  function task() {
+    var shipit = db(utils.getShipit(gruntOrShipit));
+    shipit.emit('dbFinish');
+    return shipit;
+  }
+};

--- a/tasks/db/index.js
+++ b/tasks/db/index.js
@@ -8,14 +8,17 @@ module.exports = function(gruntOrShipit) {
   require('./init')(gruntOrShipit);
   require('./pull')(gruntOrShipit);
   require('./push')(gruntOrShipit);
+  require('./finish')(gruntOrShipit);
 
   utils.registerTask(gruntOrShipit, 'db:pull', [
     'db:init',
     'db:pull:task',
+    'db:finish',
   ]);
 
   utils.registerTask(gruntOrShipit, 'db:push', [
     'db:init',
     'db:push:task',
+    'db:finish',
   ]);
 };


### PR DESCRIPTION
This PR implements a `db:finish` task and a `dbFinish` event, in analogy to `shipit-deploy`.
