### PR TITLE
Solve #7 - add dumpfetch as a task, solve #10 - add warning when deployTo isn't present in config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.log
+TEMPFILE.*
+node_modules

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Dump your remote database, download and import to local:
 shipit staging db:pull
 ```
 
+Dump your remote database, download and import to a local file:
+
+```
+shipit staging db:dumpfetch
+```
+
 ## Options (`shipit.config.db`)
 
 ### `db.ignoreTables`

--- a/tasks/db/dumpfetch.js
+++ b/tasks/db/dumpfetch.js
@@ -25,5 +25,5 @@ module.exports = function(gruntOrShipit) {
     });
   };
 
-  utils.registerTask(gruntOrShipit, 'db:dump:task', task);
+  utils.registerTask(gruntOrShipit, 'db:dumpfetch:task', task);
 };

--- a/tasks/db/dumpfetch.js
+++ b/tasks/db/dumpfetch.js
@@ -1,0 +1,29 @@
+var utils = require('shipit-utils');
+var path = require('path');
+var db = require('../../lib/db');
+
+module.exports = function(gruntOrShipit) {
+  var task = function task() {
+    var shipit = db(utils.getShipit(gruntOrShipit));
+    var dumpFile = shipit.db.dumpFile('remote');
+    var remoteDumpFilePath = path.join(shipit.sharedPath || shipit.currentPath, dumpFile);
+    var localDumpFilePath = path.join(shipit.config.workspace, dumpFile);
+
+    var download = function download() {
+      return shipit.remoteCopy(remoteDumpFilePath, localDumpFilePath, {
+        direction: 'remoteToLocal'
+      });
+    };
+
+    return shipit.db.createDirs()
+    .then(function() {
+      return shipit.db.dump('remote', remoteDumpFilePath);
+    })
+    .then(download)
+    .then(function() {
+      return shipit.db.clean('remote', remoteDumpFilePath, shipit.config.db.cleanRemote);
+    });
+  };
+
+  utils.registerTask(gruntOrShipit, 'db:dump:task', task);
+};

--- a/tasks/db/index.js
+++ b/tasks/db/index.js
@@ -8,6 +8,7 @@ module.exports = function(gruntOrShipit) {
   require('./init')(gruntOrShipit);
   require('./pull')(gruntOrShipit);
   require('./push')(gruntOrShipit);
+  require('./dumpfetch')(gruntOrShipit);
   require('./finish')(gruntOrShipit);
 
   utils.registerTask(gruntOrShipit, 'db:pull', [
@@ -19,6 +20,12 @@ module.exports = function(gruntOrShipit) {
   utils.registerTask(gruntOrShipit, 'db:push', [
     'db:init',
     'db:push:task',
+    'db:finish',
+  ]);
+
+  utils.registerTask(gruntOrShipit, 'db:dumpfetch', [
+    'db:init',
+    'db:dumpfetch:task',
     'db:finish',
   ]);
 };

--- a/tasks/db/init.js
+++ b/tasks/db/init.js
@@ -1,6 +1,7 @@
 var utils = require('shipit-utils');
 var path = require('path2/posix');
 var _ = require('lodash');
+var chalk = require('chalk');
 
 /**
  * Init task.
@@ -10,6 +11,10 @@ var _ = require('lodash');
 module.exports = function(gruntOrShipit) {
   var task = function task() {
     var shipit = utils.getShipit(gruntOrShipit);
+    if (!shipit.config.deployTo || typeof shipit.config.deployTo !== "string") {
+      shipit.log(chalk.red('Cannot initialize (db:init), as deployTo isn\'t specified in the config!'));
+      return;
+    }
     shipit.currentPath = path.join(shipit.config.deployTo, 'current');
     shipit.sharedPath = path.join(shipit.config.deployTo, 'shared');
     shipit.config.db = _.defaults(shipit.config.db || {}, {


### PR DESCRIPTION
Solve #7, add dumpfetch as a task. Which is effectively just a pull that stops short of importing. Not to the full request of the issue maker, but there was already a dumpDir config option which could be used to put the file anywhere relatively on the system.

Solve #10, or at least fix the output so the user is actually told that they need to include deployTo in their config, instead of leaving it to the user to debug from code.
