### PR TITLE
Fix MySQL syntax error when creating database with hyphens in name

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -70,7 +70,7 @@ module.exports = function(shipit) {
   };
 
   shipit.db.createCmd = function createCmd(environment) {
-    return sprintf('mysql %(credentials)s --execute \"CREATE DATABASE IF NOT EXISTS %(database)s;\"', {
+    return sprintf("mysql %(credentials)s --execute 'CREATE DATABASE IF NOT EXISTS `%(database)s`;'", {
       credentials: shipit.db.credentialParams(shipit.config.db[environment]),
       database: shipit.config.db[environment].database,
     });


### PR DESCRIPTION
Wrapped the database name in order to prevent MySQL throwing a syntax error when there is a hyphen in the name.

@timkelty I've implemented the solution provided in PR #18 but without the extras - would you be able to merge this?
