### PR TITLE
Escape MySQL create commands

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -70,7 +70,7 @@ module.exports = function(shipit) {
   };
 
   shipit.db.createCmd = function createCmd(environment) {
-    return sprintf("mysql %(credentials)s --execute 'CREATE DATABASE IF NOT EXISTS `%(database)s`;'", {
+    return sprintf('mysql %(credentials)s --execute \'CREATE DATABASE IF NOT EXISTS \\`%(database)s\\`;\'', {
       credentials: shipit.db.credentialParams(shipit.config.db[environment]),
       database: shipit.config.db[environment].database,
     });


### PR DESCRIPTION
This modification caused some unexpected problems, enclosing the database name in back ticks in some shells caused it to try and run the database name as a command and would throw the following errors:

```
@hostname-err /bin/sh: 1: database-name: not found
@hostname-err ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
```

The only way to resolve this appeared to be to wrap the MySQL query to execute in single quotes and escape the back ticks, which runs the following: 

```
mysql -u'username' -p'password' -h'host' --execute 'CREATE DATABASE IF NOT EXISTS \`database-name\`;'
```

Which appears to work consistently across sh & bash.
